### PR TITLE
Add support for running under Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM node
+
+ADD . /app
+WORKDIR /app
+
+RUN npm install
+
+EXPOSE 3000
+CMD npm start

--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 Wraps GraphiQL providing support for bearer token and arbitrary URL. Great for testing GraphQL services secured with OAuth2.0
 
+## Running with Docker
+
+`docker run -it -p3000:3000 jonwood/auth-graphiql`
+
+The service will now be listening on `http://localhost:3000`. To run on a
+different port change the first 3000 in the command, for example
+`docker run -it -p3001:3000 jonwood/auth-graphiql` will listen on port
+3001 instead.
+
 #### Install dependencies
 ```
 npm install

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-Wraps GraphiQL providing support for bearer token and arbitrary URL. Great for testing GraphQL services secured with OAuth2.0
+Wraps GraphiQL providing support for bearer token and arbitrary URL.
+Great for testing GraphQL services secured with OAuth2.0
 
 ## Running with Docker
 
@@ -9,17 +10,17 @@ different port change the first 3000 in the command, for example
 `docker run -it -p3001:3000 jonwood/auth-graphiql` will listen on port
 3001 instead.
 
-#### Install dependencies
-```
-npm install
-```
+## Running locally
 
+### Install dependencies
 
-#### Run
-```
-npm start
-```
+`npm install`
 
-#### Injoy
+### Run
 
-Provide URL and token. Introspection info will be fetched on each URL update.
+`npm start` or `env PORT=3001 npm start` to run on a different port.
+
+### Enjoy
+
+Open `http://localhost:3000`, then provide a URL and token. Information
+from the endpoint will be fetched whenever you update the URL.


### PR DESCRIPTION
This makes it much quicker to get started, at least for people with Docker already set up.

Also clarified `README.md` a bit to include details on listening to a different port.